### PR TITLE
refactor: repository pattern

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,9 @@ export default tseslint.config(
           message: '"it" should start with "should"',
         },
       ],
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
     },
   },
 );

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -11,5 +11,8 @@ export * from './filters/global-exception.filter';
 // Utils
 export * from './utils/response.util';
 
+// Repositories
+export * from './repositories';
+
 // Module
 export * from './common.module';

--- a/src/common/repositories/base-repository.abstract.ts
+++ b/src/common/repositories/base-repository.abstract.ts
@@ -1,0 +1,83 @@
+import { PrismaService } from 'prisma/prisma.service';
+import { BaseRepository } from './base-repository.interface';
+export abstract class AbstractBaseRepository<
+  T,
+  CreateInput,
+  UpdateInput,
+  WhereUniqueInput,
+> implements BaseRepository<T, CreateInput, UpdateInput, WhereUniqueInput>
+{
+  constructor(protected readonly prisma: PrismaService) {}
+
+  protected abstract getModel(): any;
+
+  protected abstract toDomainEntity(raw: any): T;
+
+  async create(data: CreateInput): Promise<T> {
+    const result = await this.getModel().create({ data });
+    return this.toDomainEntity(result);
+  }
+
+  async findUnique(where: WhereUniqueInput): Promise<T | null> {
+    const result = await this.getModel().findUnique({ where });
+    return result ? this.toDomainEntity(result) : null;
+  }
+
+  async findMany(options?: {
+    where?: any;
+    include?: any;
+    orderBy?: any;
+    skip?: number;
+    take?: number;
+  }): Promise<T[]> {
+    const results = await this.getModel().findMany(options);
+    return results.map((result: any) => this.toDomainEntity(result));
+  }
+
+  async update(where: WhereUniqueInput, data: UpdateInput): Promise<T> {
+    const result = await this.getModel().update({ where, data });
+    return this.toDomainEntity(result);
+  }
+
+  async delete(where: WhereUniqueInput): Promise<T> {
+    const result = await this.getModel().delete({ where });
+    return this.toDomainEntity(result);
+  }
+
+  async count(where?: any): Promise<number> {
+    return await this.getModel().count({ where });
+  }
+
+  async softDelete(where: WhereUniqueInput): Promise<T> {
+    const result = await this.getModel().update({
+      where,
+      data: { deletedAt: new Date() },
+    });
+    return this.toDomainEntity(result);
+  }
+
+  async restore(where: WhereUniqueInput): Promise<T> {
+    const result = await this.getModel().update({
+      where,
+      data: { deletedAt: null },
+    });
+    return this.toDomainEntity(result);
+  }
+
+  async findManyWithDeleted(options?: {
+    where?: any;
+    include?: any;
+    orderBy?: any;
+    skip?: number;
+    take?: number;
+  }): Promise<T[]> {
+    const results = await this.getModel().findMany({
+      ...options,
+      where: {
+        ...options?.where,
+        deletedAt: { not: null },
+      },
+    });
+    return results.map((result: any) => this.toDomainEntity(result));
+  }
+}

--- a/src/common/repositories/base-repository.interface.ts
+++ b/src/common/repositories/base-repository.interface.ts
@@ -1,0 +1,29 @@
+export interface BaseRepository<
+  T,
+  _CreateInput,
+  _UpdateInput,
+  WhereUniqueInput,
+> {
+  create(data: any): Promise<T>;
+  findUnique(where: WhereUniqueInput): Promise<T | null>;
+  findMany(options?: {
+    where?: any;
+    include?: any;
+    orderBy?: any;
+    skip?: number;
+    take?: number;
+  }): Promise<T[]>;
+  update(where: WhereUniqueInput, data: any): Promise<T>;
+  delete(where: WhereUniqueInput): Promise<T>;
+  count(where?: any): Promise<number>;
+
+  softDelete?(where: WhereUniqueInput): Promise<T>;
+  restore?(where: WhereUniqueInput): Promise<T>;
+  findManyWithDeleted?(options?: {
+    where?: any;
+    include?: any;
+    orderBy?: any;
+    skip?: number;
+    take?: number;
+  }): Promise<T[]>;
+}

--- a/src/common/repositories/index.ts
+++ b/src/common/repositories/index.ts
@@ -1,0 +1,2 @@
+export * from './base-repository.interface';
+export * from './base-repository.abstract';

--- a/src/redis/guards/rate-limit.guard.ts
+++ b/src/redis/guards/rate-limit.guard.ts
@@ -73,7 +73,7 @@ export class RateLimitGuard implements CanActivate {
 
   private getDefaultKey(request: Request): string {
     const ip = request.ip || request.connection.remoteAddress || 'unknown';
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+
     const route = ((request as any).route?.path as string) || request.url;
     return `rate_limit:${ip}:${route}`;
   }

--- a/src/staff-accounts/repositories/index.ts
+++ b/src/staff-accounts/repositories/index.ts
@@ -1,0 +1,2 @@
+export * from './staff-account.repository.interface';
+export * from './staff-account.repository.impl';

--- a/src/staff-accounts/repositories/staff-account.repository.impl.ts
+++ b/src/staff-accounts/repositories/staff-account.repository.impl.ts
@@ -1,0 +1,290 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma, StaffRole } from '@prisma/client';
+import { PrismaService } from 'prisma/prisma.service';
+import { AbstractBaseRepository } from '../../common/repositories';
+import { StaffAccount } from '../domain/staff-account';
+import { CreateStaffAccountDto } from '../dto/create-staff-account.dto';
+import { FilterStaffAccountsDto } from '../dto/filter-staff-accounts.dto';
+import { UpdateStaffAccountDto } from '../dto/update-staff-account.dto';
+import { StaffAccountRepository } from './staff-account.repository.interface';
+
+@Injectable()
+export class StaffAccountRepositoryImpl
+  extends AbstractBaseRepository<
+    StaffAccount,
+    CreateStaffAccountDto,
+    UpdateStaffAccountDto,
+    Prisma.StaffAccountWhereUniqueInput
+  >
+  implements StaffAccountRepository
+{
+  constructor(prisma: PrismaService) {
+    super(prisma);
+  }
+
+  protected getModel() {
+    return this.prisma.staffAccount;
+  }
+
+  protected toDomainEntity(raw: Partial<StaffAccount>): StaffAccount {
+    return new StaffAccount(raw);
+  }
+
+  async findByEmail(
+    email: string,
+    includeRelations = false,
+  ): Promise<StaffAccount | null> {
+    const result = await this.getModel().findFirst({
+      where: { email, deletedAt: null },
+      include: includeRelations
+        ? {
+            doctor: true,
+            blogs: true,
+          }
+        : undefined,
+    });
+
+    return result ? this.toDomainEntity(result) : null;
+  }
+
+  async findByEmailWithPassword(email: string): Promise<StaffAccount | null> {
+    const result = await this.getModel().findFirst({
+      where: { email, deletedAt: null },
+      select: {
+        id: true,
+        fullName: true,
+        email: true,
+        passwordHash: true,
+        role: true,
+        gender: true,
+        dateOfBirth: true,
+        deletedAt: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    return result ? this.toDomainEntity(result) : null;
+  }
+
+  async findByRole(
+    role: StaffRole,
+    includeRelations = false,
+    pagination?: { skip: number; take: number },
+  ): Promise<StaffAccount[]> {
+    const results = await this.getModel().findMany({
+      where: { role, deletedAt: null },
+      include: includeRelations
+        ? {
+            doctor: true,
+            blogs: true,
+          }
+        : undefined,
+      orderBy: {
+        createdAt: 'desc',
+      },
+      ...(pagination && { skip: pagination.skip, take: pagination.take }),
+    });
+
+    return results.map((result) => this.toDomainEntity(result));
+  }
+
+  async findAllWithFilters(
+    filterDto: FilterStaffAccountsDto,
+    pagination?: { skip: number; take: number },
+  ): Promise<StaffAccount[]> {
+    const where = this.buildFilterWhere(filterDto);
+    const orderBy = this.buildFilterOrderBy(filterDto);
+
+    const results = await this.getModel().findMany({
+      where,
+      include: filterDto.includeRelations
+        ? {
+            doctor: true,
+            blogs: true,
+          }
+        : undefined,
+      orderBy,
+      ...(pagination && { skip: pagination.skip, take: pagination.take }),
+    });
+
+    return results.map((result) => this.toDomainEntity(result));
+  }
+
+  async countWithFilters(filterDto: FilterStaffAccountsDto): Promise<number> {
+    const where = this.buildFilterWhere(filterDto);
+    return this.getModel().count({ where });
+  }
+
+  async countByRole(role: StaffRole): Promise<number> {
+    return this.getModel().count({
+      where: { role, deletedAt: null },
+    });
+  }
+
+  async findDeletedAccounts(pagination?: {
+    skip: number;
+    take: number;
+  }): Promise<StaffAccount[]> {
+    const results = await this.getModel().findMany({
+      where: { deletedAt: { not: null } },
+      orderBy: { deletedAt: 'desc' },
+      ...(pagination && { skip: pagination.skip, take: pagination.take }),
+    });
+
+    return results.map((result) => this.toDomainEntity(result));
+  }
+
+  async getStatistics(): Promise<{
+    total: number;
+    byRole: Record<StaffRole, number>;
+    recentlyCreated: number;
+    active: number;
+  }> {
+    const [total, adminCount, doctorCount, superAdminCount] = await Promise.all(
+      [
+        this.count({ deletedAt: null }),
+        this.countByRole(StaffRole.ADMIN),
+        this.countByRole(StaffRole.DOCTOR),
+        this.countByRole(StaffRole.SUPER_ADMIN),
+      ],
+    );
+
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    const recentlyCreated = await this.getModel().count({
+      where: {
+        deletedAt: null,
+        createdAt: {
+          gte: thirtyDaysAgo,
+        },
+      },
+    });
+
+    return {
+      total,
+      byRole: {
+        [StaffRole.SUPER_ADMIN]: superAdminCount,
+        [StaffRole.ADMIN]: adminCount,
+        [StaffRole.DOCTOR]: doctorCount,
+      },
+      recentlyCreated,
+      active: total,
+    };
+  }
+
+  async adminResetPassword(
+    staffAccountId: string,
+    passwordHash: string,
+  ): Promise<void> {
+    await this.getModel().update({
+      where: { id: staffAccountId },
+      data: { passwordHash },
+    });
+  }
+
+  async adminDelete(id: string): Promise<void> {
+    await this.getModel().update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  async findMany(options?: {
+    where?: any;
+    include?: any;
+    orderBy?: any;
+    skip?: number;
+    take?: number;
+  }): Promise<StaffAccount[]> {
+    const whereWithActiveCheck = {
+      ...options?.where,
+      deletedAt: null,
+    };
+
+    return super.findMany({
+      ...options,
+      where: whereWithActiveCheck,
+    });
+  }
+
+  async findUnique(
+    where: Prisma.StaffAccountWhereUniqueInput,
+  ): Promise<StaffAccount | null> {
+    const result = await this.getModel().findUnique({
+      where: { ...where, deletedAt: null },
+    });
+
+    return result ? this.toDomainEntity(result) : null;
+  }
+
+  private buildFilterWhere(
+    filterDto: FilterStaffAccountsDto,
+  ): Prisma.StaffAccountWhereInput {
+    const { role, gender, search, email, createdFrom, createdTo } = filterDto;
+
+    const where: Prisma.StaffAccountWhereInput = {
+      deletedAt: null,
+    };
+
+    if (role) {
+      where.role = role;
+    }
+
+    if (gender) {
+      where.gender = gender;
+    }
+
+    if (email) {
+      where.email = {
+        contains: email,
+        mode: 'insensitive',
+      };
+    }
+
+    if (search) {
+      where.OR = [
+        {
+          fullName: {
+            contains: search,
+            mode: 'insensitive',
+          },
+        },
+        {
+          email: {
+            contains: search,
+            mode: 'insensitive',
+          },
+        },
+      ];
+    }
+
+    if (createdFrom || createdTo) {
+      where.createdAt = {};
+      if (createdFrom) {
+        where.createdAt.gte = new Date(createdFrom);
+      }
+      if (createdTo) {
+        where.createdAt.lte = new Date(createdTo);
+      }
+    }
+
+    return where;
+  }
+
+  private buildFilterOrderBy(
+    filterDto: FilterStaffAccountsDto,
+  ): Prisma.StaffAccountOrderByWithRelationInput {
+    const { sortBy, sortOrder } = filterDto;
+
+    const orderBy: Prisma.StaffAccountOrderByWithRelationInput = {};
+    if (sortBy) {
+      orderBy[sortBy] = sortOrder || 'desc';
+    } else {
+      orderBy.createdAt = 'desc';
+    }
+
+    return orderBy;
+  }
+}

--- a/src/staff-accounts/repositories/staff-account.repository.interface.ts
+++ b/src/staff-accounts/repositories/staff-account.repository.interface.ts
@@ -1,0 +1,54 @@
+import { Prisma, StaffRole } from '@prisma/client';
+import { BaseRepository } from '../../common/repositories';
+import { StaffAccount } from '../domain/staff-account';
+import { CreateStaffAccountDto } from '../dto/create-staff-account.dto';
+import { FilterStaffAccountsDto } from '../dto/filter-staff-accounts.dto';
+import { UpdateStaffAccountDto } from '../dto/update-staff-account.dto';
+
+export interface StaffAccountRepository
+  extends BaseRepository<
+    StaffAccount,
+    CreateStaffAccountDto,
+    UpdateStaffAccountDto,
+    Prisma.StaffAccountWhereUniqueInput
+  > {
+  findByEmail(
+    email: string,
+    includeRelations?: boolean,
+  ): Promise<StaffAccount | null>;
+
+  findByRole(
+    role: StaffRole,
+    includeRelations?: boolean,
+    pagination?: { skip: number; take: number },
+  ): Promise<StaffAccount[]>;
+
+  findAllWithFilters(
+    filterDto: FilterStaffAccountsDto,
+    pagination?: { skip: number; take: number },
+  ): Promise<StaffAccount[]>;
+
+  countWithFilters(filterDto: FilterStaffAccountsDto): Promise<number>;
+
+  countByRole(role: StaffRole): Promise<number>;
+
+  findDeletedAccounts(pagination?: {
+    skip: number;
+    take: number;
+  }): Promise<StaffAccount[]>;
+
+  getStatistics(): Promise<{
+    total: number;
+    byRole: Record<StaffRole, number>;
+    recentlyCreated: number;
+    active: number;
+  }>;
+
+  findByEmailWithPassword(email: string): Promise<StaffAccount | null>;
+
+  adminResetPassword(
+    staffAccountId: string,
+    passwordHash: string,
+  ): Promise<void>;
+  adminDelete(id: string): Promise<void>;
+}

--- a/src/staff-accounts/staff-accounts.module.ts
+++ b/src/staff-accounts/staff-accounts.module.ts
@@ -1,13 +1,20 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
+import { StaffAccountRepositoryImpl } from './repositories';
 import { StaffAccountProtectedController } from './staff-accounts-protected.controller';
 import { StaffAccountsService } from './staff-accounts.service';
 
 @Module({
   imports: [PrismaModule, forwardRef(() => AuthModule)],
   controllers: [StaffAccountProtectedController],
-  providers: [StaffAccountsService],
-  exports: [StaffAccountsService],
+  providers: [
+    StaffAccountsService,
+    {
+      provide: 'StaffAccountRepository',
+      useClass: StaffAccountRepositoryImpl,
+    },
+  ],
+  exports: [StaffAccountsService, 'StaffAccountRepository'],
 })
 export class StaffAccountsModule {}

--- a/src/staff-accounts/staff-accounts.service.spec.ts
+++ b/src/staff-accounts/staff-accounts.service.spec.ts
@@ -1,33 +1,44 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { PrismaService } from '../../prisma/prisma.service';
+import { StaffAccountRepository } from './repositories';
 import { StaffAccountsService } from './staff-accounts.service';
 
 describe('StaffAccountsService', () => {
   let service: StaffAccountsService;
-  let prismaService: PrismaService;
+  let repository: StaffAccountRepository;
   let module: TestingModule;
+
+  const mockRepository = {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    findMany: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    count: jest.fn(),
+    findByEmail: jest.fn(),
+    findByRole: jest.fn(),
+    findAllWithFilters: jest.fn(),
+    countWithFilters: jest.fn(),
+    countByRole: jest.fn(),
+    findDeletedAccounts: jest.fn(),
+    getStatistics: jest.fn(),
+    findByEmailWithPassword: jest.fn(),
+    adminResetPassword: jest.fn(),
+    adminDelete: jest.fn(),
+  };
 
   beforeEach(async () => {
     module = await Test.createTestingModule({
       providers: [
         StaffAccountsService,
         {
-          provide: PrismaService,
-          useValue: {
-            staffAccount: {
-              findMany: jest.fn(),
-              findUnique: jest.fn(),
-              create: jest.fn(),
-              update: jest.fn(),
-              delete: jest.fn(),
-            },
-          },
+          provide: 'StaffAccountRepository',
+          useValue: mockRepository,
         },
       ],
     }).compile();
 
     service = module.get<StaffAccountsService>(StaffAccountsService);
-    prismaService = module.get<PrismaService>(PrismaService);
+    repository = module.get<StaffAccountRepository>('StaffAccountRepository');
   });
 
   afterEach(async () => {
@@ -40,7 +51,7 @@ describe('StaffAccountsService', () => {
     expect(service).toBeDefined();
   });
 
-  it('should have prisma service injected', () => {
-    expect(prismaService).toBeDefined();
+  it('should have repository injected', () => {
+    expect(repository).toBeDefined();
   });
 });

--- a/src/utils/transformers/lower-case.transformer.ts
+++ b/src/utils/transformers/lower-case.transformer.ts
@@ -3,5 +3,4 @@ import { MaybeType } from '../types/maybe.type';
 
 export const lowerCaseTransformer = (
   params: TransformFnParams,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 ): MaybeType<string> => params.value?.toLowerCase().trim() as string;

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';


### PR DESCRIPTION
This pull request introduces a repository abstraction layer for staff accounts and refactors the staff account service to use this new layer. It also adds a generic base repository pattern for Prisma models, improving code modularity and testability. The most significant changes include the implementation of repository interfaces and classes, dependency injection updates, and corresponding test refactoring.

### Repository Abstraction & Implementation

* Added a generic `BaseRepository` interface and an abstract implementation `AbstractBaseRepository` to standardize CRUD operations and soft deletion logic for Prisma models. (`src/common/repositories/base-repository.interface.ts`, `src/common/repositories/base-repository.abstract.ts`, `src/common/repositories/index.ts`) [[1]](diffhunk://#diff-d96d7a116190327ad9f3dc0926650065b8d52043ca1cf3faa7d23cca2cc3b64bR1-R29) [[2]](diffhunk://#diff-517752d35482708b9ede19bd9bb210584460032f4176f53a761a092a660d29a5R1-R83) [[3]](diffhunk://#diff-c34e20ee6a4e39a3cc355a2ecdef3c076a5e97c9e10116d60485dc8801250a29R1-R2)
* Implemented `StaffAccountRepositoryImpl`, providing concrete repository methods for staff accounts, including advanced queries and statistics. (`src/staff-accounts/repositories/staff-account.repository.impl.ts`)
* Defined a `StaffAccountRepository` interface to specify repository operations for staff accounts. (`src/staff-accounts/repositories/staff-account.repository.interface.ts`)

### Dependency Injection & Service Refactor

* Updated `StaffAccountsService` to use the injected `StaffAccountRepository` instead of direct Prisma service calls, refactoring all relevant methods to delegate to the repository. (`src/staff-accounts/staff-accounts.service.ts`) [[1]](diffhunk://#diff-75c3012fac02ca49d2882a8ef9cec13bb730eea04d87676f5dbe0384ef3adb38L1-L4) [[2]](diffhunk://#diff-75c3012fac02ca49d2882a8ef9cec13bb730eea04d87676f5dbe0384ef3adb38R12-R28) [[3]](diffhunk://#diff-75c3012fac02ca49d2882a8ef9cec13bb730eea04d87676f5dbe0384ef3adb38L34-R50) [[4]](diffhunk://#diff-75c3012fac02ca49d2882a8ef9cec13bb730eea04d87676f5dbe0384ef3adb38L66-R100)
* Registered the repository implementation in the module providers and exports for dependency injection. (`src/staff-accounts/staff-accounts.module.ts`)

### Testing

* Refactored the staff account service tests to use a mock repository instead of Prisma, updating test setup and assertions accordingly. (`src/staff-accounts/staff-accounts.service.spec.ts`) [[1]](diffhunk://#diff-c67dc32b3cb8cd8c36f0e9e6bfbd05ace15c956a91a5bc156cc2b7f5a81ad4f8L2-R41) [[2]](diffhunk://#diff-c67dc32b3cb8cd8c36f0e9e6bfbd05ace15c956a91a5bc156cc2b7f5a81ad4f8L43-R55)

### Miscellaneous

* Exported the new repositories from the common and staff accounts modules for easier imports. (`src/common/index.ts`, `src/staff-accounts/repositories/index.ts`) [[1]](diffhunk://#diff-182b244087b852548048fe4f962c988384d596c6b26ce24953e4223602424a5eR14-R16) [[2]](diffhunk://#diff-84d64cc7cb6afd43649caa9d60b3475afaf1f87dd4ce40e461311352e0784a73R1-R2)
* Disabled several TypeScript ESLint unsafe rules to reduce noise for repository pattern code. (`eslint.config.mjs`)
* Minor code cleanup in the rate limit guard. (`src/redis/guards/rate-limit.guard.ts`)